### PR TITLE
Mirror all the images in the manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Example:
 ## Requirements
 To be installed on the bastion host used for the mirroring process:
 + [Podman](https://github.com/containers/libpod)
-+ [Skopeo](https://github.com/containers/skopeo)
++ [Skopeo >= 0.1.40](https://github.com/containers/skopeo)
 + Python3
 
 On RHEL8/Centos8/Fedora systems you can install them with:

--- a/mirror_csv_release.sh
+++ b/mirror_csv_release.sh
@@ -163,7 +163,7 @@ mirror() {
     for source_image in "$@"; do
         dest_image=$(get_dest_image "${source_image}" "${dest_prefix}")
         echo -e "\e[41mMirroring ${source_image} -> ${dest_image}\e[49m"
-        bash -c "$dry_run skopeo copy $dest_secret docker://${source_image} docker://${dest_image}"
+        bash -c "$dry_run skopeo copy --all $dest_secret docker://${source_image} docker://${dest_image}"
     done
 
 }


### PR DESCRIPTION
The manifest can contain images for different
architectures.
Use --all options on skopeo (only since 0.1.40)
to mirror all the images.

See: https://bugzilla.redhat.com/1794040