### PR TITLE
Optionally fetch the CSV directly from appregistry

### DIFF
--- a/Dockerfile_appregistry
+++ b/Dockerfile_appregistry
@@ -1,0 +1,18 @@
+FROM quay.io/openshift/origin-operator-registry:latest
+
+USER 0
+RUN rm -rf /manifests \
+    && rm -rf /db \
+    && mkdir -p /manifests \
+    && mkdir -p /db \
+    && touch /db/bundles.db \
+    && chown -R 1001:1001 /db
+
+USER 1001
+COPY patched_manifests/ /manifests
+
+# Initialize the database
+RUN initializer --manifests /manifests/ --output /db/bundles.db
+
+ENTRYPOINT ["registry-server"]
+CMD ["--database", "/db/bundles.db"]

--- a/README.md
+++ b/README.md
@@ -14,16 +14,18 @@ The metadata image is patched to point to the new registry, rebuilt and publishe
 Usage:
 
 mirror_csv_release.sh [options] SOURCE_BUNDLE_REGISTRY DEST_PREFIX
+mirror_csv_release.sh [options] --appregistry DEST_PREFIX
 
 Mirror container images listed in an operator bundle.
 
 Positional arguments:
-    SOURCE_BUNDLE_REGISTRY
+    [SOURCE_BUNDLE_REGISTRY]
         Will be used for:
           - Extract bundle files
           - Get the list of images listed in the bundle
           - Replacement string when replace the source registry and namespace
             with the destination registry and namespace.
+        SOURCE_BUNDLE_REGISTRY should be omitted when fetching the content directly from an appregistry (--appregistry)
 
         [e.g quay.io/openshift-cnv/container-native-virtualization-hco-bundle-registry:v2.2.0-181]
 
@@ -34,11 +36,14 @@ Positional arguments:
        [e.g quay.io/tiraboschi/]
 
 Optional arguments:
-    -s,--dest-secret USERNAME[:PASSWORD]
+    --dest-secret USERNAME[:PASSWORD]
         for accessing the destination registry
 
     --version-filter
         to mirror just a specific version
+
+    --appregistry
+        to fetch the source CSVs from the specified appregistry instead of a bundle image
 
     -d,--debug
         run in debug mode
@@ -46,8 +51,33 @@ Optional arguments:
     --dry-run
         dry-run mode
 
+    --baseurl
+        appregistry API baseurl, used only in appregistry mode
+        default: https://quay.io/cnr
+
+    --appregistry-name
+        appregistry name, used only in appregistry mode
+        default: redhat-operators
+
+    --package-name)
+        package name, used only in appregistry mode
+        default: kubevirt-hyperconverged
+
+    --packageversion
+        package version, used only in appregistry mode
+        default: 1.0.0
+
+    --bundle-registry-name
+        name of the destination bundle registry image, used only in appregistry mode
+        default: bundle-registry
+
+    --bundle-registry-tag
+        tag of the destination bundle registry image, used only in appregistry mode
+        default: 1.0.0
+
 Example:
-    mirror_csv_release.sh  --version-filter 2.2.0 quay.io/openshift-cnv/container-native-virtualization-hco-bundle-registry:v2.2.0-181  quay.io/tiraboschi/
+    mirror_csv_release.sh  --version-filter 2.2.0 quay.io/openshift-cnv/container-native-virtualization-hco-bundle-registry:v2.2.0-181 quay.io/tiraboschi/
+    mirror_csv_release.sh  --appregistry --version-filter 2.2.0 --packageversion 4.0.0 --bundle-registry-name my-bundle-registry --bundle-registry-tag 1.0.0 quay.io/tiraboschi/
 ```
 
 ## Requirements

--- a/mirror_csv_release.sh
+++ b/mirror_csv_release.sh
@@ -6,16 +6,18 @@ usage () {
 Usage:
 
 ${0##*/} [options] SOURCE_BUNDLE_REGISTRY DEST_PREFIX
+${0##*/} [options] --appregistry DEST_PREFIX
 
 Mirror container images listed in an operator bundle.
 
 Positional arguments:
-    SOURCE_BUNDLE_REGISTRY
+    [SOURCE_BUNDLE_REGISTRY]
         Will be used for:
           - Extract bundle files
           - Get the list of images listed in the bundle
           - Replacement string when replace the source registry and namespace
             with the destination registry and namespace.
+        SOURCE_BUNDLE_REGISTRY should be omitted when fetching the content directly from an appregistry (--appregistry)
 
         [e.g quay.io/openshift-cnv/container-native-virtualization-hco-bundle-registry:v2.2.0-181]
 
@@ -26,11 +28,14 @@ Positional arguments:
        [e.g quay.io/tiraboschi/]
 
 Optional arguments:
-    -s,--dest-secret USERNAME[:PASSWORD]
+    --dest-secret USERNAME[:PASSWORD]
         for accessing the destination registry
 
     --version-filter
         to mirror just a specific version
+
+    --appregistry
+        to fetch the source CSVs from the specified appregistry instead of a bundle image
 
     -d,--debug
         run in debug mode
@@ -38,8 +43,33 @@ Optional arguments:
     --dry-run
         dry-run mode
 
+    --baseurl
+        appregistry API baseurl, used only in appregistry mode
+        default: https://quay.io/cnr
+
+    --appregistry-name
+        appregistry name, used only in appregistry mode
+        default: redhat-operators
+
+    --package-name)
+        package name, used only in appregistry mode
+        default: kubevirt-hyperconverged
+
+    --packageversion
+        package version, used only in appregistry mode
+        default: 1.0.0
+
+    --bundle-registry-name
+        name of the destination bundle registry image, used only in appregistry mode
+        default: bundle-registry
+
+    --bundle-registry-tag
+        tag of the destination bundle registry image, used only in appregistry mode
+        default: 1.0.0
+
 Example:
-    ${0##*/}  --version-filter 2.2.0 quay.io/openshift-cnv/container-native-virtualization-hco-bundle-registry:v2.2.0-181  quay.io/tiraboschi/
+    ${0##*/}  --version-filter 2.2.0 quay.io/openshift-cnv/container-native-virtualization-hco-bundle-registry:v2.2.0-181 quay.io/tiraboschi/
+    ${0##*/}  --appregistry --version-filter 2.2.0 --packageversion 4.0.0 --bundle-registry-name my-bundle-registry --bundle-registry-tag 1.0.0 quay.io/tiraboschi/
 
 "
 }
@@ -57,13 +87,20 @@ main() {
     local csv_files
     local source_images=()
     local dest_secret=""
+    local source_secret=""
     local version_filter=""
+    local baseurl="https://quay.io/cnr"
+    local appregistry_name="redhat-operators"
+    local package_name="kubevirt-hyperconverged"
+    local packageversion="1.0.0"
+    local bundle_registry_name="bundle-registry"
+    local bundle_registry_tag="test"
     local options
 
     options=$( \
         getopt \
             -o hs:p:d \
-            --long help,version-filter:,dest-secret:,debug,dry-run \
+            --long help,version-filter:,dest-secret:,source-secret:,debug,dry-run,appregistry,baseurl:,appregistry-name:,package-name:,packageversion:,bundle-registry-name:,bundle-registry-tag: \
             -n "$0" \
             -- "$@" \
     )
@@ -75,8 +112,12 @@ main() {
 
     while true; do
         case $1 in
-            -s|--dest-secret)
+            --dest-secret)
                 dest_secret="$2"
+                shift 2
+                ;;
+            --source-secret)
+                source_secret="$2"
                 shift 2
                 ;;
             --version-filter)
@@ -91,9 +132,37 @@ main() {
                 DRY_RUN=true
                 shift 1
                 ;;
+            --appregistry)
+                APPREGISTRY=true
+                shift 1
+                ;;
             -h|--help)
                 usage
                 exit 0
+                ;;
+            --baseurl)
+                baseurl="$2"
+                shift 2
+                ;;
+            --appregistry-name)
+                appregistry_name="$2"
+                shift 2
+                ;;
+            --package-name)
+                package_name="$2"
+                shift 2
+                ;;
+            --packageversion)
+                packageversion="$2"
+                shift 2
+                ;;
+            --bundle-registry-name)
+                bundle_registry_name="$2"
+                shift 2
+                ;;
+            --bundle-registry-tag)
+                bundle_registry_tag="$2"
+                shift 2
                 ;;
             --)
                 shift
@@ -103,15 +172,34 @@ main() {
     done
 
     # Positional arguments
-    local bundle_image="${1:?usage SOURCE_BUNDLE_REGISTRY was not specified}"
-    local dest_prefix="${2:?usage DEST_PREFIX was not specified}"
+    local bundle_image=""
+    local dest_prefix=""
 
-    get_bundle_content "$bundle_image"
+    if [[ "$APPREGISTRY" ]]; then
+        # Positional arguments
+        dest_prefix="${1:?usage DEST_PREFIX was not specified}"
+        local wrong_bundle_image="${2}"
+        if [[ "$wrong_bundle_image" ]]; then
+            echo "SOURCE_BUNDLE_REGISTRY should be omitted in appregistry mode"
+            exit -1
+        fi
+        get_bundle_content_appregistry "${baseurl}" "${appregistry_name}" "${package_name}" "${packageversion}" "${source_secret}"
+    else
+        # Positional arguments
+        bundle_image="${1:?usage SOURCE_BUNDLE_REGISTRY was not specified}"
+        dest_prefix="${2:?usage DEST_PREFIX was not specified}"
+        get_bundle_content "$bundle_image"
+    fi
     csv_files=($(get_csv_files $version_filter))
     source_images=($(get_source_images "${csv_files[@]}"))
 
     mirror "$dest_prefix" "$dest_secret" "${source_images[@]}"
-    build_and_publish_patched_bundle_image "$bundle_image" "$dest_prefix"
+
+    if [[ "$APPREGISTRY" ]]; then
+        build_and_publish_patched_bundle_image_appregistry "${source_images[0]}" "$dest_prefix" "${bundle_registry_name}" "${bundle_registry_tag}"
+    else
+        build_and_publish_patched_bundle_image "$bundle_image" "$dest_prefix"
+    fi
 }
 
 
@@ -122,6 +210,21 @@ get_bundle_content() {
     podman rm ${container_id}
 }
 
+get_bundle_content_appregistry() {
+    local baseurl="${1:?}"
+    local appregistry_name="${2:?}"
+    local package_name="${3:?}"
+    local version="${4:?}"
+    local source_secret="${5}"
+    local url="${baseurl}/api/v1/packages/${appregistry_name}/${package_name}/${version}/helm/pull"
+    local auth=''
+    if [[ "$source_secret" ]]; then
+        auth="-H 'Authorization: basic ${source_secret}'"
+    fi
+    curl ${auth} "${url}" --output ${tmp_dir}/bundle.tar.gz
+    mkdir ${tmp_dir}/manifests
+    tar -xzvf ${tmp_dir}/bundle.tar.gz -C ${tmp_dir}/manifests
+}
 
 get_csv_files() {
     local version_filter="${1}"
@@ -173,9 +276,9 @@ mirror() {
         local n=0
         until [[ $n -ge 5 ]]
         do
-           bash -c "$dry_run skopeo copy $all $dest_secret docker://${source_image} docker://${dest_image}" && break
-           n=$[$n+1]
-           sleep 15
+            bash -c "$dry_run skopeo copy $all $dest_secret docker://${source_image} docker://${dest_image}" && break
+            n=$[$n+1]
+            sleep 15
         done
     done
 
@@ -192,14 +295,49 @@ build_and_publish_patched_bundle_image() {
     cp Dockerfile ${tmp_dir}
     echo -e "\e[41mRecreating bundle registry image\e[49m"
     podman build --build-arg PARENT_IMAGE="${bundle_image}" \
-       --build-arg SOURCE="${source_registry}" \
-       --build-arg DESTINATION="${dest_prefix}"  ${tmp_dir} -t "${dest_image}"
-    bash -c "$dry_run podman push ${dest_image}"
+        --build-arg SOURCE="${source_registry}" \
+        --build-arg DESTINATION="${dest_prefix}"  ${tmp_dir} -t "${dest_image}"
+    local n=0
+    until [[ $n -ge 5 ]]
+    do
+        bash -c "$dry_run podman push ${dest_image}" && break
+        n=$[$n+1]
+        sleep 15
+    done
+}
+
+build_and_publish_patched_bundle_image_appregistry() {
+    local source_image="${1:?}"
+    local dest_prefix="${2:?}"
+    local bundle_registry_name="${3:?}"
+    local bundle_registry_tag="${4:?}"
+    local source_registry=${source_image%\/*}/
+    local dest_image=$(get_dest_image "${bundle_image}" "${dest_prefix}")
+    local dry_run
+    [[ "$DRY_RUN" ]] && dry_run=echo
+
+    dest_image=${dest_prefix}${bundle_registry_name}:${bundle_registry_tag}
+
+    mv "$(find ${tmp_dir}/manifests -maxdepth 1 -mindepth 1 -type d)" ${tmp_dir}/patched_manifests
+    find ${tmp_dir}/patched_manifests -name *clusterserviceversion* \
+    | xargs \
+    sed -i "s,${source_registry},${dest_prefix},g"
+
+    cp Dockerfile_appregistry ${tmp_dir}/Dockerfile
+    echo -e "\e[41mRecreating bundle registry image\e[49m"
+    podman build ${tmp_dir} -t "${dest_image}"
+    local n=0
+    until [[ $n -ge 5 ]]
+    do
+        bash -c "$dry_run podman push ${dest_image}" && break
+        n=$[$n+1]
+        sleep 15
+    done
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     main "$@"
 else
-    # Don't fail if somone try to source this script
+    # Don't fail if someone tries to source this script
     :
 fi


### PR DESCRIPTION
Implement additional logic to fetch the CSV
directly from the appregistry, patch it, mirror
the images as usual and build a custom bundle registry
image from the patched CSV.